### PR TITLE
Separate API reference from main index and document result codes whic…

### DIFF
--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -1,0 +1,12 @@
+API Reference
+=============
+
+.. autoclass:: mock_vws.MockVWS
+
+.. autoclass:: mock_vws.target.Target
+
+.. autoclass:: mock_vws.states.States
+   :members:
+   :undoc-members:
+
+.. autoclass:: mock_vws.database.VuforiaDatabase

--- a/docs/source/differences-to-vws.rst
+++ b/docs/source/differences-to-vws.rst
@@ -85,3 +85,18 @@ NGINX Error cases
 Vuforia uses NGINX.
 This has error handling which is not duplicated in the mock.
 For example, Vuforia returns a 400 (``BAD REQUEST``) response if a header or cookie is given which is larger than 8 KiB.
+
+Result codes
+------------
+
+Result codes are returned by requests to Vuforia to help with debugging.
+See `How To Interpret VWS API Result Codes <https://library.vuforia.com/articles/Solution/How-To-Use-the-Vuforia-Web-Services-API#How-To-Interperete-VWS-API-Result-Codes>`_ for details of the available result codes.
+There are some result codes which the mock cannot return.
+
+These are:
+
+* ``RequestQuotaReached``
+* ``DateRangeError``
+* ``TargetQuotaReached``
+* ``ProjectSuspended``
+* ``ProjectHasNoAPIAccess``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,28 +18,13 @@ Using the mock redirects requests to Vuforia made with `requests <https://pypi.o
         # This will use the Vuforia mock.
         requests.get('https://vws.vuforia.com/summary')
 
-By default, an exception will be raised if any requests to unmocked addresses are made.
-
-
-Reference
----------
-
-.. autoclass:: mock_vws.target.Target
-
-.. autoclass:: mock_vws.states.States
-   :members:
-   :undoc-members:
-
-.. autoclass:: mock_vws.MockVWS
-
-.. autoclass:: mock_vws.database.VuforiaDatabase
-
 Reference
 ---------
 
 .. toctree::
    :maxdepth: 3
 
+   api-reference
    installation
    differences-to-vws
    versioning-and-api-stability


### PR DESCRIPTION
…h are not handled